### PR TITLE
fix: correct `CMD`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -169,7 +169,7 @@ _:
           Cmd = [
             ''
               ${extraCmd};
-              if [ -n \"$GRAMINE_DIRECT\" ]; then
+              if [ -n "$GRAMINE_DIRECT" ]; then
                   exec gramine-direct ${name};
               else
                   [[ -r /var/run/aesmd/aesm.socket ]] || restart-aesmd >&2;


### PR DESCRIPTION
incorrectly escaped `[ -n "$GRAMINE_DIRECT" ]`