### PR TITLE
feat: rename manifest and sigs to `app` by default via `appName` parameter

### DIFF
--- a/packages/nixsgx-test-sgx-azure/default.nix
+++ b/packages/nixsgx-test-sgx-azure/default.nix
@@ -1,25 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
-{ lib
-, pkgs
-, inputs
-, nixsgx
-, hello
-}:
-pkgs.callPackage lib.nixsgx.mkSGXContainer {
-  name = "nixsgx-test-sgx-azure";
-  tag = "latest";
-
-  packages = [ hello ];
-  entrypoint = lib.meta.getExe hello;
-
+{ nixsgx }: nixsgx.nixsgx-test-sgx-dcap.override {
+  container-name = "nixsgx-test-sgx-azure";
   isAzure = true;
-
-  manifest = {
-    sgx = {
-      edmm_enable = false;
-      enclave_size = "32M";
-      max_threads = 2;
-    };
-  };
 }

--- a/packages/nixsgx-test-sgx-dcap/default.nix
+++ b/packages/nixsgx-test-sgx-dcap/default.nix
@@ -5,15 +5,18 @@
 , inputs
 , nixsgx
 , hello
+, isAzure ? false
+, container-name ? "nixsgx-test-sgx-dcap"
+, tag ? "latest"
 }:
 pkgs.callPackage lib.nixsgx.mkSGXContainer {
-  name = "nixsgx-test-sgx-dcap";
-  tag = "latest";
+  name = container-name;
+  inherit tag isAzure;
 
   packages = [ hello ];
   entrypoint = lib.meta.getExe hello;
 
-  isAzure = false;
+  extraCmd = "echo \"Starting ${container-name}\"; gramine-sgx-sigstruct-view app.sig";
 
   manifest = {
     sgx = {


### PR DESCRIPTION
This will ease the creation of scripts processing containers further.