### PR TITLE
chore: Migrate from cachix to Attic in nix and github workflows

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,34 +12,44 @@ concurrency:
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            sandbox = true
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: https://attic.teepot.org/
+          cache: tee-pot
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - run: nix fmt . -- --check
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            sandbox = true
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: https://attic.teepot.org/
+          cache: tee-pot
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
@@ -47,17 +57,22 @@ jobs:
 
   build:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            sandbox = true
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0
         with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: https://attic.teepot.org/
+          cache: tee-pot
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/flake.lock
+++ b/flake.lock
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717281328,
-        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
+        "lastModified": 1719707984,
+        "narHash": "sha256-RoxIr/fbndtuKqulGvNCcuzC6KdAib85Q8gXnjzA1dw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
+        "rev": "7dca15289a1c2990efbe4680f0923ce14139b042",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716675292,
-        "narHash": "sha256-7TFvVE4HR/b65/0AAhewYHEJzUXxIEJn82ow5bCkrDo=",
+        "lastModified": 1719005984,
+        "narHash": "sha256-mpFl3Jv4fKnn+5znYXG6SsBjfXHJdRG5FEqNSPx0GLA=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "5d6e9f235735393c28e1145bec919610b172a20f",
+        "rev": "c6238c83de101729c5de3a29586ba166a9a65622",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,8 @@
 {
-  nixConfig.extra-substituters = [
-    "https://nixsgx.cachix.org"
-  ];
-  nixConfig.extra-trusted-public-keys = [
-    "nixsgx.cachix.org-1:tGi36DlY2joNsIXOlGnSgWW0+E094V6hW0umQRo/KoE="
-  ];
+  nixConfig = {
+    extra-substituters = [ "https://attic.teepot.org/tee-pot" ];
+    extra-trusted-public-keys = [ "tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=" ];
+  };
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";

--- a/packages/sgx-sdk/default.nix
+++ b/packages/sgx-sdk/default.nix
@@ -18,6 +18,7 @@
 , python3
 , texinfo
 , validatePkgConfig
+, which
 , writeShellApplication
 , writeShellScript
 , writeText
@@ -91,6 +92,7 @@ stdenv.mkDerivation rec {
     python3
     texinfo
     validatePkgConfig
+    which
   ];
 
   buildInputs = [


### PR DESCRIPTION
- Updated nix config to use Attic substituter and trusted public key
- Modified github workflows to use Attic cache instead of Cachix
- Removed the now unnecessary cachix config settings and Cachix workflow actions
- Update `flake.lock`
- Run on our own CI runners
