### PR TITLE
fix: get rid of `/dev/` in containers

### DIFF
--- a/overlays/nixsgxLib/default.nix
+++ b/overlays/nixsgxLib/default.nix
@@ -211,7 +211,6 @@ final: _:
                   inherit fromImage;
 
                   includeStorePaths = false;
-                  enableFakechroot = true;
                   extraCommands = (mkNixStore contents) + ''
                     (
                       set -e


### PR DESCRIPTION
`enableFakechroot = true` somehow triggered the inclusion of `/dev`.

Some fake chroots included `/dev/kvm` with different permissions, so the produced container was not the same.

As this fake chroot is not needed anymore with using `--chroot` for `gramine-sgx-sign`, it can be turned off.