### PR TITLE
feat(sgxGramineContainer): expose maxLayers argument from image builder

### DIFF
--- a/overlays/libTee/sgxGramineContainer.nix
+++ b/overlays/libTee/sgxGramineContainer.nix
@@ -22,6 +22,7 @@
 , sigFile ? null
 , extendedPackages ? [ ]
 , customRecursiveMerge ? null
+, maxLayers ? 100
 }:
 assert lib.assertMsg (!(isAzure && sgx_default_qcnl_conf != null)) "sgx_default_qcnl_conf can't be set for Azure";
 let
@@ -201,6 +202,7 @@ let
         inherit tag;
         inherit contents;
         inherit fromImage;
+        inherit maxLayers;
 
         includeStorePaths = false;
         extraCommands = (mkNixStore contents) + ''
@@ -231,6 +233,7 @@ let
           inherit config;
           inherit tag;
           inherit fromImage;
+          inherit maxLayers;
 
           includeStorePaths = false;
           extraCommands = ''
@@ -247,6 +250,7 @@ let
         inherit tag;
         inherit config;
         inherit fromImage;
+        inherit maxLayers;
         contents = extendedContents;
       };
 in


### PR DESCRIPTION
### Summary

The current `sgxGramineContainer` builder uses a lot of layers by itself, not leaving much room for more complex enclaves before hitting a compile time error. Allowing users to adjust the maxLayers parameter is sufficient to solve the issue.

```
error: builder for '/nix/store/nr78hkr0x4s1rq5xz69yvk3hxgcpqzpy-foobar-manifest-app-conf.json.drv' failed with exit code 1;
       last 1 log lines:
       > Error: usedLayers 101 layers to store 'fromImage' and 'extraCommands', but only maxLayers=100 were allowed. At least 1 layer is required to store contents.
```

### What's changed

- Exposed the `maxLayers` argument from `dockerTools.buildLayeredImage` and uses it throughout the builder in each step