### PR TITLE
docs: add test enclave usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixsgx
 
-This repository contains a Nix flake with up2date packages for the Intel SGX SDK and gramine.
+This repository contains a Nix flake with up-to-date packages for the Intel SGX SDK and gramine.
 
 Hopefully most of the packages will be upstreamed to nixpkgs at some point.
 
@@ -8,5 +8,29 @@ All package builds should be reproducible and therefore can be used to build rep
 
 ## Usage
 
-See: https://github.com/matter-labs/teepot
-and https://github.com/matter-labs/era-fee-withdrawer/tree/gramine-sgx
+### Test enclave
+
+A testing enclave container is provided and can be ran like so:
+
+```sh
+# Build the dcap (or azure) container variant
+nix build .#nixsgx-test-sgx-dcap
+
+# Load image into docker
+docker load < result
+
+# Run the enclave, binding the sgx devices
+docker run -i --init --rm \
+  --device /dev/sgx_enclave \
+  --device /dev/sgx_provision \
+  nixsgx-test-sgx-dcap:latest
+```
+
+> Note: An external aesmd instance can be provided by mounting the socket to the container: `-v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket`
+
+### Reference projects
+
+The following projects provide reproducible enclaves using nixsgx:
+
+- https://github.com/matter-labs/teepot
+- https://github.com/matter-labs/era-fee-withdrawer/tree/gramine-sgx


### PR DESCRIPTION
### What's changed?

- Added usage subsection for running the test enclave
- Moved reference projects to its own usage subsection
- s/up2date/up-to-date